### PR TITLE
fix: isolation in pseudo-elements and normal selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ When a rule contains both normal selectors and pseudo-element selectors, the plu
 }
 ```
 
+The plugin distinguishes between rules containing:
+
+1. Only pseudo-elements - No warning about missing `isolation: isolate`, warns if it's present as redundant
+2. At least one normal element - Warning about missing `isolation: isolate` when position and z-index are present
+
 #### Multiple z-index Declarations
 
 When a rule contains multiple `z-index` declarations (except `z-index: auto`), the plugin will report errors for each non-auto declaration:


### PR DESCRIPTION
This pull request refines the behavior of a Stylelint plugin to better handle rules involving pseudo-elements and normal selectors. The changes primarily focus on distinguishing between these cases, improving error reporting, and simplifying the code logic.

### Improvements to pseudo-element and normal selector handling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R106): Updated documentation to clarify how the plugin handles rules with pseudo-elements versus normal selectors. Rules with only pseudo-elements will not warn about missing `isolation: isolate` but will warn if it's redundant. Rules with at least one normal selector will warn about missing `isolation: isolate` when `position` and `z-index` are present.

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L43-L44): Adjusted the logic to ensure that rules containing only pseudo-elements (`isAllPseudoElements`) do not trigger warnings about missing `isolation: isolate`. Simplified the conditional checks by removing the `hasNormalSelectors` variable and directly using `!isAllPseudoElements` where needed. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L43-L44) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L121-R127)

### Code simplification:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L87): Removed the unused `nonAutoZIndexItems` array, as it was no longer necessary for the updated logic.